### PR TITLE
New version 1.6.8.82

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,17 @@ FROM alpine:3.3
 
 MAINTAINER info.inspectit@novatec-gmbh.de
 
-ENV INSPECTIT_VERSION 1.6.7.79
+ENV INSPECTIT_VERSION 1.6.8.82
 
 COPY dumb-init /dumb-init
 
 RUN apk --no-cache add ca-certificates wget \
  && wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.22-r5/glibc-2.22-r5.apk \
  && apk --allow-untrusted add glibc-2.22-r5.apk \
- && wget --no-check-certificate -O /inspectit-cmr.linux.x64.tar.gz https://github.com/inspectIT/inspectIT/releases/download/${INSPECTIT_VERSION}/inspectit-cmr.linux.x64.tar.gz \
- && gunzip /inspectit-cmr.linux.x64.tar.gz \
- && tar xf /inspectit-cmr.linux.x64.tar \
+ && wget --no-check-certificate -O /inspectit-cmr.linux.x64.zip https://github.com/inspectIT/inspectIT/releases/download/${INSPECTIT_VERSION}/inspectit-cmr.linux.x64-${INSPECTIT_VERSION}.zip \
+ && unzip /inspectit-cmr.linux.x64.zip -d . \
  && rm *.apk \
- && rm /inspectit-cmr.linux.x64.tar
+ && rm /inspectit-cmr.linux.x64.zip
 
 WORKDIR /CMR
 


### PR DESCRIPTION
Upgraded to new version 1.6.8.82.

I had to make more changes that expected, because the new version uses `.zip` archives instead of `.tar.gz`.
